### PR TITLE
Show error if password auth failed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,9 +198,15 @@ async function handlePassword(username, password) {
   if (!username || !password) {
     throw new Error("Password authentication requires username and password");
   }
-  await exec.exec("cf", ["auth", username, password], {
-    silent: true,
-  });
+  try {
+    await exec.exec("cf", ["auth", username, password], {
+      silent: true,
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to authenticate using password: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   core.info(">>> Successfully authenticated using password");
 }
 


### PR DESCRIPTION
This is currently being swallowed which sucks as you don't know what is failing as a user.

I used this action in my actions workflow and it took me a while to figure out that the 
reason it was failing with:

>>> CF CLI v8.8.3 installed successfully
>>> Successfully set CF API endpoint
Error: The process '/opt/actions-runner/_work/_tool/cf/8.8.3/x64/cf' failed with exit code 1

was simply due to a typo in a username secret.

Instead of the try/catch I could also live with setting silent to false, which will output the cf cli response containing some more details on the error.

Could also think about doing this for other all auth types as well.

